### PR TITLE
VCT compliant (draft-ietf-oauth-sd-jwt-vc-13)

### DIFF
--- a/credentials/eduid.vct
+++ b/credentials/eduid.vct
@@ -1,4 +1,5 @@
 {
+  "vct": "nl.surf.eduid",
   "name": "eduID",
   "description": "eduID indicates affiliation with an institute of higher education or research",
   "display": [
@@ -33,270 +34,172 @@
   ],
   "claims": [
     {
-      "path": [
-        "schac_home_organization"
-      ],
+      "path": ["schac_home_organization"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "Organization",
-          "description": "Organization",
-          "lang": "en"
-        },
-        {
-          "name": "Instelling",
-          "description": "Instelling",
-          "lang": "nl"
-        }
+        { "label": "Organization", "description": "Organization", "lang": "en" },
+        { "label": "Instelling", "description": "Instelling", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "name"
-      ],
+      "path": ["name"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "Name",
-          "description": "Full name",
-          "lang": "en"
-        },
-        {
-          "name": "Naam",
-          "description": "Volledige naam",
-          "lang": "nl"
-        }
+        { "label": "Name", "description": "Full name", "lang": "en" },
+        { "label": "Naam", "description": "Volledige naam", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "given_name"
-      ],
+      "path": ["given_name"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "Given name",
-          "description": "Given name or first name",
-          "lang": "en"
-        },
-        {
-          "name": "Voornaam",
-          "description": "Voornaam",
-          "lang": "nl"
-        }
+        { "label": "Given name", "description": "Given name or first name", "lang": "en" },
+        { "label": "Voornaam", "description": "Voornaam", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "family_name"
-      ],
+      "path": ["family_name"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "Family name",
-          "description": "Family name or surname",
-          "lang": "en"
-        },
-        {
-          "name": "Achternaam",
-          "description": "Achternaam met tussenvoegsels",
-          "lang": "nl"
-        }
+        { "label": "Family name", "description": "Family name or surname", "lang": "en" },
+        { "label": "Achternaam", "description": "Achternaam met tussenvoegsels", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "email"
-      ],
+      "path": ["email"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "E-mail",
-          "description": "E-mail address",
-          "lang": "en"
-        },
-        {
-          "name": "E-mail",
-          "description": "E-mail adres",
-          "lang": "nl"
-        }
+        { "label": "E-mail", "description": "E-mail address", "lang": "en" },
+        { "label": "E-mail", "description": "E-mail adres", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "eduperson_scoped_affiliation"
-      ],
+      "path": ["eduperson_scoped_affiliation"],
       "sd": "allowed",
       "display": [
         {
-          "name": "Affiliation (scoped)",
+          "label": "Affiliation (scoped)",
           "description": "Affiliation scoped to the home organization",
           "lang": "en"
         },
         {
-          "name": "Betrekking (in relatie)",
+          "label": "Betrekking (in relatie)",
           "description": "Betrekking in relatie tot de instelling",
           "lang": "nl"
         }
       ]
     },
     {
-      "path": [
-        "eduperson_assurance"
-      ],
+      "path": ["eduperson_assurance"],
       "sd": "never",
       "display": [
         {
-          "name": "Assurance",
+          "label": "Assurance",
           "description": "Assurance level for receiving this credential",
           "lang": "en"
         },
         {
-          "name": "Bevestiging",
+          "label": "Bevestiging",
           "description": "Bevestigingsniveau voor het verkrijgen van dit credential",
           "lang": "nl"
         }
       ]
     },
     {
-      "path": [
-        "is_student"
-      ],
+      "path": ["is_student"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "IsStudent",
-          "description": "Is the holder a student",
-          "lang": "en"
-        },
-        {
-          "name": "IsStudent",
-          "description": "Is de houder een student",
-          "lang": "nl"
-        }
+        { "label": "IsStudent", "description": "Is the holder a student", "lang": "en" },
+        { "label": "IsStudent", "description": "Is de houder een student", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "is_faculty"
-      ],
+      "path": ["is_faculty"],
       "sd": "allowed",
       "display": [
-        {
-          "name": "IsFaculty",
-          "description": "Is the holder a faculty member",
-          "lang": "en"
-        },
-        {
-          "name": "IsFaculteitslid",
-          "description": "Is de houder een faculteitslid",
-          "lang": "nl"
-        }
+        { "label": "IsFaculty", "description": "Is the holder a faculty member", "lang": "en" },
+        { "label": "IsFaculteitslid", "description": "Is de houder een faculteitslid", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "is_member"
-      ],
+      "path": ["is_member"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsMember",
+          "label": "IsMember",
           "description": "Is the holder a member of the organisation",
           "lang": "en"
         },
-        {
-          "name": "IsLid",
-          "description": "Is de houder lid van de organisatie",
-          "lang": "nl"
-        }
+        { "label": "IsLid", "description": "Is de houder lid van de organisatie", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "is_staff"
-      ],
+      "path": ["is_staff"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsStaff",
+          "label": "IsStaff",
           "description": "Is the holder a staff member of the organisation",
           "lang": "en"
         },
-        {
-          "name": "IsStaf",
-          "description": "Is de houder een staflid van de organisatie",
-          "lang": "nl"
-        }
+        { "label": "IsStaf", "description": "Is de houder een staflid van de organisatie", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "is_alum"
-      ],
+      "path": ["is_alum"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsAlumnus",
+          "label": "IsAlumnus",
           "description": "Is the holder an alumnus of the organisation",
           "lang": "en"
         },
         {
-          "name": "IsAlumnus",
+          "label": "IsAlumnus",
           "description": "Is de houder een alumnus van de organisatie",
           "lang": "nl"
         }
       ]
     },
     {
-      "path": [
-        "is_affiliate"
-      ],
+      "path": ["is_affiliate"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsAffiliate",
+          "label": "IsAffiliate",
           "description": "Is the holder affiliated with the organisation",
           "lang": "en"
         },
-        {
-          "name": "IsVerbonden",
-          "description": "Is de houder verbonden met de organisatie",
-          "lang": "nl"
-        }
+        { "label": "IsVerbonden", "description": "Is de houder verbonden met de organisatie", "lang": "nl" }
       ]
     },
     {
-      "path": [
-        "is_employee"
-      ],
+      "path": ["is_employee"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsEmployee",
+          "label": "IsEmployee",
           "description": "Is the holder an employee of the organisation",
           "lang": "en"
         },
         {
-          "name": "IsMedewerker",
+          "label": "IsMedewerker",
           "description": "Is de houder een medewerker van de organisatie",
           "lang": "nl"
         }
       ]
     },
     {
-      "path": [
-        "is_library-walk-in"
-      ],
+      "path": ["is_library-walk-in"],
       "sd": "allowed",
       "display": [
         {
-          "name": "IsLibraryWalkIn",
+          "label": "IsLibraryWalkIn",
           "description": "Is the holder a library-walk-in of this organisation",
           "lang": "en"
         },
         {
-          "name": "IsBibliotheekBezoeker",
+          "label": "IsBibliotheekBezoeker",
           "description": "Is de houder een bezoeker van de bibliotheek van de organisatie",
           "lang": "nl"
         }

--- a/credentials/eduid.vct
+++ b/credentials/eduid.vct
@@ -4,7 +4,7 @@
   "description": "eduID indicates affiliation with an institute of higher education or research",
   "display": [
     {
-      "lang": "en",
+      "locale": "en",
       "name": "eduID",
       "description": "eduID indicates affiliation with an institute of higher education or research",
       "rendering": {
@@ -18,7 +18,7 @@
       }
     },
     {
-      "lang": "nl-NL",
+      "locale": "nl-NL",
       "name": "eduID",
       "description": "eduID geeft een relatie aan met een hoger onderwijsinstelling of onderzoeksinstituut",
       "rendering": {
@@ -37,40 +37,40 @@
       "path": ["schac_home_organization"],
       "sd": "allowed",
       "display": [
-        { "label": "Organization", "description": "Organization", "lang": "en" },
-        { "label": "Instelling", "description": "Instelling", "lang": "nl" }
+        { "label": "Organization", "description": "Organization", "locale": "en" },
+        { "label": "Instelling", "description": "Instelling", "locale": "nl" }
       ]
     },
     {
       "path": ["name"],
       "sd": "allowed",
       "display": [
-        { "label": "Name", "description": "Full name", "lang": "en" },
-        { "label": "Naam", "description": "Volledige naam", "lang": "nl" }
+        { "label": "Name", "description": "Full name", "locale": "en" },
+        { "label": "Naam", "description": "Volledige naam", "locale": "nl" }
       ]
     },
     {
       "path": ["given_name"],
       "sd": "allowed",
       "display": [
-        { "label": "Given name", "description": "Given name or first name", "lang": "en" },
-        { "label": "Voornaam", "description": "Voornaam", "lang": "nl" }
+        { "label": "Given name", "description": "Given name or first name", "locale": "en" },
+        { "label": "Voornaam", "description": "Voornaam", "locale": "nl" }
       ]
     },
     {
       "path": ["family_name"],
       "sd": "allowed",
       "display": [
-        { "label": "Family name", "description": "Family name or surname", "lang": "en" },
-        { "label": "Achternaam", "description": "Achternaam met tussenvoegsels", "lang": "nl" }
+        { "label": "Family name", "description": "Family name or surname", "locale": "en" },
+        { "label": "Achternaam", "description": "Achternaam met tussenvoegsels", "locale": "nl" }
       ]
     },
     {
       "path": ["email"],
       "sd": "allowed",
       "display": [
-        { "label": "E-mail", "description": "E-mail address", "lang": "en" },
-        { "label": "E-mail", "description": "E-mail adres", "lang": "nl" }
+        { "label": "E-mail", "description": "E-mail address", "locale": "en" },
+        { "label": "E-mail", "description": "E-mail adres", "locale": "nl" }
       ]
     },
     {
@@ -80,12 +80,12 @@
         {
           "label": "Affiliation (scoped)",
           "description": "Affiliation scoped to the home organization",
-          "lang": "en"
+          "locale": "en"
         },
         {
           "label": "Betrekking (in relatie)",
           "description": "Betrekking in relatie tot de instelling",
-          "lang": "nl"
+          "locale": "nl"
         }
       ]
     },
@@ -96,12 +96,12 @@
         {
           "label": "Assurance",
           "description": "Assurance level for receiving this credential",
-          "lang": "en"
+          "locale": "en"
         },
         {
           "label": "Bevestiging",
           "description": "Bevestigingsniveau voor het verkrijgen van dit credential",
-          "lang": "nl"
+          "locale": "nl"
         }
       ]
     },
@@ -109,84 +109,56 @@
       "path": ["is_student"],
       "sd": "allowed",
       "display": [
-        { "label": "IsStudent", "description": "Is the holder a student", "lang": "en" },
-        { "label": "IsStudent", "description": "Is de houder een student", "lang": "nl" }
+        { "label": "IsStudent", "description": "Is the holder a student", "locale": "en" },
+        { "label": "IsStudent", "description": "Is de houder een student", "locale": "nl" }
       ]
     },
     {
       "path": ["is_faculty"],
       "sd": "allowed",
       "display": [
-        { "label": "IsFaculty", "description": "Is the holder a faculty member", "lang": "en" },
-        { "label": "IsFaculteitslid", "description": "Is de houder een faculteitslid", "lang": "nl" }
+        { "label": "IsFaculty", "description": "Is the holder a faculty member", "locale": "en" },
+        { "label": "IsFaculteitslid", "description": "Is de houder een faculteitslid", "locale": "nl" }
       ]
     },
     {
       "path": ["is_member"],
       "sd": "allowed",
       "display": [
-        {
-          "label": "IsMember",
-          "description": "Is the holder a member of the organisation",
-          "lang": "en"
-        },
-        { "label": "IsLid", "description": "Is de houder lid van de organisatie", "lang": "nl" }
+        { "label": "IsMember", "description": "Is the holder a member of the organisation", "locale": "en" },
+        { "label": "IsLid", "description": "Is de houder lid van de organisatie", "locale": "nl" }
       ]
     },
     {
       "path": ["is_staff"],
       "sd": "allowed",
       "display": [
-        {
-          "label": "IsStaff",
-          "description": "Is the holder a staff member of the organisation",
-          "lang": "en"
-        },
-        { "label": "IsStaf", "description": "Is de houder een staflid van de organisatie", "lang": "nl" }
+        { "label": "IsStaff", "description": "Is the holder a staff member of the organisation", "locale": "en" },
+        { "label": "IsStaf", "description": "Is de houder een staflid van de organisatie", "locale": "nl" }
       ]
     },
     {
       "path": ["is_alum"],
       "sd": "allowed",
       "display": [
-        {
-          "label": "IsAlumnus",
-          "description": "Is the holder an alumnus of the organisation",
-          "lang": "en"
-        },
-        {
-          "label": "IsAlumnus",
-          "description": "Is de houder een alumnus van de organisatie",
-          "lang": "nl"
-        }
+        { "label": "IsAlumnus", "description": "Is the holder an alumnus of the organisation", "locale": "en" },
+        { "label": "IsAlumnus", "description": "Is de houder een alumnus van de organisatie", "locale": "nl" }
       ]
     },
     {
       "path": ["is_affiliate"],
       "sd": "allowed",
       "display": [
-        {
-          "label": "IsAffiliate",
-          "description": "Is the holder affiliated with the organisation",
-          "lang": "en"
-        },
-        { "label": "IsVerbonden", "description": "Is de houder verbonden met de organisatie", "lang": "nl" }
+        { "label": "IsAffiliate", "description": "Is the holder affiliated with the organisation", "locale": "en" },
+        { "label": "IsVerbonden", "description": "Is de houder verbonden met de organisatie", "locale": "nl" }
       ]
     },
     {
       "path": ["is_employee"],
       "sd": "allowed",
       "display": [
-        {
-          "label": "IsEmployee",
-          "description": "Is the holder an employee of the organisation",
-          "lang": "en"
-        },
-        {
-          "label": "IsMedewerker",
-          "description": "Is de houder een medewerker van de organisatie",
-          "lang": "nl"
-        }
+        { "label": "IsEmployee", "description": "Is the holder an employee of the organisation", "locale": "en" },
+        { "label": "IsMedewerker", "description": "Is de houder een medewerker van de organisatie", "locale": "nl" }
       ]
     },
     {
@@ -196,12 +168,12 @@
         {
           "label": "IsLibraryWalkIn",
           "description": "Is the holder a library-walk-in of this organisation",
-          "lang": "en"
+          "locale": "en"
         },
         {
           "label": "IsBibliotheekBezoeker",
           "description": "Is de houder een bezoeker van de bibliotheek van de organisatie",
-          "lang": "nl"
+          "locale": "nl"
         }
       ]
     }


### PR DESCRIPTION
Suggested changes:
- vct is REQUIRED in the Type Metadata document and therefore added
- Type-level display[] uses name but Claim-level display[] uses label therefore changed
- type display[] and claim display[] use locale not lang anymore therefore updated

https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-13.html#name-display-metadata (The display property is an array containing display information for the type. name: A human-readable name for the type, intended for end users. This property is REQUIRED)
https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-13.html#name-claim-display-metadata (The display property is an array containing display information for the claim. label: A human-readable label for the claim, intended for end users. This property is REQUIRED)
https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-13.html#appendix-D (Change lang to locale. While lang is more accurate, locale is what has traditionally been used in OpenID Connect and later related specs)


